### PR TITLE
Cache monorepo package lookups

### DIFF
--- a/src/rules/no-internal-import.js
+++ b/src/rules/no-internal-import.js
@@ -2,10 +2,10 @@ import moduleVisitor, {
   makeOptionsSchema,
 } from 'eslint-module-utils/moduleVisitor';
 import parse from 'parse-package-name';
-import getPackages from 'get-monorepo-packages';
 import path from 'path';
 import minimatch from 'minimatch';
 import fs from 'fs';
+import getPackages from '../util/get-packages';
 
 export const meta = {
   schema: [makeOptionsSchema({})],

--- a/src/rules/no-relative-import.js
+++ b/src/rules/no-relative-import.js
@@ -5,7 +5,7 @@ import moduleVisitor, {
 import isInside from 'path-is-inside';
 import minimatch from 'minimatch';
 import path from 'path';
-import getPackages from 'get-monorepo-packages';
+import getPackages from '../util/get-packages';
 
 export const meta = {
   schema: [makeOptionsSchema({})],

--- a/src/util/get-packages.js
+++ b/src/util/get-packages.js
@@ -1,0 +1,15 @@
+import getPackages from 'get-monorepo-packages';
+
+const packageMap = new Map();
+
+export default function getPackagesWithCache(directory) {
+  // We assume that the set of monorepo packages for this directory will
+  // not change during a single eslint run
+  let packages = packageMap.get(directory);
+  if (!packages) {
+    packages = getPackages(directory);
+    packageMap.set(directory, packages);
+  }
+
+  return packages;
+}


### PR DESCRIPTION
I noticed that the rules call `getPackages` from `get-monorepo-packages` many times per execution, even when `directory` is the same (which I'd imagine it always is?). So just adding a module-level cache here saves us some work.

This isn't a _huge_ time saving, but experimentally in a large monorepo I saw it shave off ~30s of total time on a ~2m run, which is non-negligible.

This PR assumes that it's safe to do this: if it's not safe, due to something I've overlooked, the alternative (better) approach is probably to add a config option allowing users to pass in a list of monorepo paths, so it doesn't need to be calculated at all by the plugin. Though if this is fine then it's less work since it doesn't require a new config option + documentation etc.